### PR TITLE
Add Fedora Package Pre-Requisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,10 +87,15 @@ Modern Paste is intended for system administrators who wish to host their own in
    + `FLASK_SECRET_KEY` - For security reasons, replace the string here with the output of `os.urandom(32)` from a Python shell.
 
 5. **Build the app.**
-   At this point, before continuing, ensure you have the MySQL and Python dev packages installed. This corrects common errors during the `make dependencies` stage of the build.
+   At this point, before continuing, ensure you have the MySQL and Python dev packages installed. This corrects common errors during the `make dependencies` stage of the build. To avoid conflicts with the system Python's modules, it is recommended to use [pyenv](https://github.com/yyuu/pyenv) so the app's Python dependencies remain segregated from the base system's environment. 
    ```bash
    $ sudo apt-get install build-essential python-dev libmysqlclient-dev
    ```
+   Or for Fedora/RedHat varients:
+   ```bash
+   $ sudo dnf install python-devel community-mysql-devel redhat-rpm-config mod_wsgi gem npm community-mysql-server
+   $ sudo dnf groupinstall "C Development Tools and Libraries"
+   $ sudo dnf groupinstall "Development Tools"
    Then, in the directory you cloned the repository to:
    ```bash
    $ sudo make

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Modern Paste is intended for system administrators who wish to host their own in
    + `FLASK_SECRET_KEY` - For security reasons, replace the string here with the output of `os.urandom(32)` from a Python shell.
 
 5. **Build the app.**
-   At this point, before continuing, ensure you have the MySQL and Python dev packages installed. This corrects common errors during the `make dependencies` stage of the build. To avoid conflicts with the system Python's modules, it is recommended to use [pyenv](https://github.com/yyuu/pyenv) so the app's Python dependencies remain segregated from the base system's environment. 
+   At this point, before continuing, ensure you have the MySQL and Python dev packages installed. This corrects common errors during the `make dependencies` stage of the build. To avoid conflicts with the system Python's modules, it is recommended to use [pyenv](https://github.com/yyuu/pyenv) so the app's Python dependencies remain segregated from the base system's environment.
    ```bash
    $ sudo apt-get install build-essential python-dev libmysqlclient-dev
    ```

--- a/README.md
+++ b/README.md
@@ -91,11 +91,12 @@ Modern Paste is intended for system administrators who wish to host their own in
    ```bash
    $ sudo apt-get install build-essential python-dev libmysqlclient-dev
    ```
-   Or for Fedora/RedHat varients:
+   Or for Fedora/RedHat variants:
    ```bash
    $ sudo dnf install python-devel community-mysql-devel redhat-rpm-config mod_wsgi gem npm community-mysql-server
    $ sudo dnf groupinstall "C Development Tools and Libraries"
    $ sudo dnf groupinstall "Development Tools"
+   ```
    Then, in the directory you cloned the repository to:
    ```bash
    $ sudo make


### PR DESCRIPTION
This is an effort to assist users of RHEL (and its major variants such as Fedora or CentOS) with building and running modern-paste by updating readme.md with Fedora-specific package names for prerequisite packages, such as for development libraries that have different names from their Debian counterparts.

This is not 100% complete, as during testing with Fedora 25 I was able to get a mostly working app, excluding setting expiration dates, which result in Internal 500 errors that I have not been able to track down yet. Password-protected posts, encrypted paste URLs, registration, and others all seem to work fine, however, so I felt this was worth a PR after seeing #22.

**pyenv**
After breaking my initial Fedora 25 test system's local Python installation as a result of modern-paste calling pip directly and creating system module conflicts during the build process, I started using pyenv to segregate modern-paste's Python behaviour to a dedicated local environment and suggest recommending this by default in the readme to prevent inexperienced users from breaking local Python installations with module conflicts.