### PR TITLE
Add Perl to the list of "default" languages in the build script

### DIFF
--- a/app/config.py
+++ b/app/config.py
@@ -89,6 +89,7 @@ LANGUAGES = [
     'jinja2',
     'markdown',
     'octave',
+    'perl',
     'php',
     'python',
     'sass',


### PR DESCRIPTION
The build script may not be "default" languages, but a lot of installations will probably use whatever is shipped as their starting point. Perl should at least be in that list.