### PR TITLE
Fix JS errors with some codemirror modes

### DIFF
--- a/app/templates/paste/post.html
+++ b/app/templates/paste/post.html
@@ -15,6 +15,7 @@
     {{ import_js([
         'lib/date-time-picker/build/jquery.datetimepicker.full.min.js',
         'lib/codemirror/lib/codemirror.js',
+        'lib/codemirror/addon/mode/simple.js',
         'paste/PostController.js',
     ])|safe }}
 

--- a/app/templates/paste/view.html
+++ b/app/templates/paste/view.html
@@ -13,6 +13,7 @@
 
     {{ import_js([
         'lib/codemirror/lib/codemirror.js',
+        'lib/codemirror/addon/mode/simple.js',
         'paste/ViewController.js',
     ])|safe }}
 

--- a/app/templates/paste/view.html
+++ b/app/templates/paste/view.html
@@ -16,8 +16,14 @@
         'paste/ViewController.js',
     ])|safe }}
 
-    {% if paste.language != 'text' %}
-        {{ import_js(['lib/codemirror/mode/' ~ paste.language ~ '/' ~ paste.language ~ '.js'], defer=True)|safe }}
+     {% if config.BUILD_ENVIRONMENT == 'dev' %}
+        {% for language in config.LANGUAGES %}
+            {% if language != 'text' %}
+                {{ import_js(['lib/codemirror/mode/' ~ language ~ '/' ~ language ~ '.js'], defer=True)|safe }}
+            {% endif %}
+        {% endfor %}
+    {% else %}
+        {{ import_js(['paste/modes.js'], defer=True)|safe }}
     {% endif %}
 {% endblock %}
 


### PR DESCRIPTION
Always load all CodeMirror modes in view.html since some CodeMirror modes depend on others.
This fixes #43.

Add CodeMirror simple addon which is needed by some modes.