### PR TITLE
Mark success response parameter on /api/paste/submit as optional

### DIFF
--- a/app/templates/misc/api_documentation.html
+++ b/app/templates/misc/api_documentation.html
@@ -169,7 +169,7 @@ assert set(resp.json().keys()) == {
                     <tr>
                         <td width="20%"><span class="ubuntu-mono regular size-2">success</span></td>
                         <td width="15%"><span class="ubuntu-mono regular size-2">boolean</span></td>
-                        <td width="65%"><span class="sans-serif regular size-2"><span class="ubuntu-mono regular">true</span> if the request was successful; <span class="ubuntu-mono regular">false</span> otherwise.</span></td>
+                        <td width="65%"><span class="sans-serif regular size-2"><span class="ubuntu-mono regular">true</span> if the request was successful; <span class="ubuntu-mono regular">false</span> otherwise.</span> This field is not present on a successful request.</td>
                     </tr>
                     <tr>
                         <td width="20%"><span class="ubuntu-mono regular size-2">message</span></td>


### PR DESCRIPTION
This mirrors the current state of the code: `app/api/paste.py`
does not set the `constants.api.RESULT` ('success') field and
`app/models/paste.py` does not contain a success field. This
means that on a successful paste, `/api/paste/submit` will lack
a 'success' field.


Perhaps this field is unnecessary and the preferred fix would be to remove it altogether; however, this at least documents the current state of things. This was discovered against https://paste.fedoraproject.org. 